### PR TITLE
Arranged sign in Wallet.cs in order to limit size to 64bytes.

### DIFF
--- a/sacco/Code/TxSigner.cs
+++ b/sacco/Code/TxSigner.cs
@@ -83,7 +83,6 @@ namespace commercio.sacco.lib
             Dictionary<String, Object> sortedJson = MapSorter.sort(jsonSignature);
             // Encode the sorted JSON to a string
             String jsonData = JsonConvert.SerializeObject(sortedJson);
-             // Create a Sha256 of the message
             byte[] utf8Bytes = Encoding.UTF8.GetBytes(jsonData);
            
             // Sign the message


### PR DESCRIPTION
Arranged deriveFrom in TransactionSigner in order to use the same approach.
Cleanup of various test code.